### PR TITLE
Fix accessing get_ros1_messages from cmake

### DIFF
--- a/ros1_message_mirror/cmake/rosidl_from_ros1_package.cmake
+++ b/ros1_message_mirror/cmake/rosidl_from_ros1_package.cmake
@@ -9,8 +9,7 @@ macro(rosidl_from_ros1_package package)
     find_package(${dependency})
   endforeach()
 
-  # TODO(pbovbel) register bin path
-  set(bin_path ${CMAKE_INSTALL_PREFIX}/lib/ros1_message_mirror)
+  set(bin_path ${ros1_message_mirror_LIBEXEC_DIR})
 
   set(message_types "msg" "srv" "action")
 

--- a/ros1_message_mirror/ros1_message_mirror-extras.cmake
+++ b/ros1_message_mirror/ros1_message_mirror-extras.cmake
@@ -1,2 +1,13 @@
 include("${CMAKE_CURRENT_LIST_DIR}/find_ros1_package.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/rosidl_from_ros1_package.cmake")
+
+# Export the lib directory so other packages can get the correct path for
+# scripts under .../lib/
+# CMAKE_CURRENT_LIST_DIR points to .../share/ros1_message_mirror/cmake,
+# we need .../lib/ros1_message_mirror.
+get_filename_component(up1 "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)       # .../share/ros1_message_mirror
+get_filename_component(up2 "${up1}" DIRECTORY)                          # .../share
+get_filename_component(ros1_message_mirror_PREFIX "${up2}" DIRECTORY)   # .../<prefix>
+
+set(ros1_message_mirror_LIBEXEC_DIR
+  "${ros1_message_mirror_PREFIX}/lib/ros1_message_mirror")


### PR DESCRIPTION
This works with merged installs, but otherwise does not because the CMAKE_INSTALL_PREFIX points to the current package being build (json_msgs) for example, not ros1_message_mirror.

Per Paul's comment, instead of using CMAKE_INSTALL_PREFIX we can export the correct path from ros1_message_mirror so dependent packages can find the script.